### PR TITLE
Fix the Layer Mask of SeeBehindSettings_Renderer to use SeeBehind instead of SeeThrough

### DIFF
--- a/URP-Videos-Complete/Assets/Scenes/Renderer Features See Behind/SeeBehindSettings_Renderer.asset
+++ b/URP-Videos-Complete/Assets/Scenes/Renderer Features See Behind/SeeBehindSettings_Renderer.asset
@@ -52,7 +52,7 @@ MonoBehaviour:
       type: 3}
     objectMotionVector: {fileID: 4800000, guid: 7b3ede40266cd49a395def176e1bc486,
       type: 3}
-  m_AssetVersion: 1
+  m_AssetVersion: 2
   m_OpaqueLayerMask:
     serializedVersion: 2
     m_Bits: 311
@@ -69,6 +69,7 @@ MonoBehaviour:
   m_ShadowTransparentReceive: 0
   m_RenderingMode: 0
   m_DepthPrimingMode: 0
+  m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0
   m_ClusteredRendering: 0
   m_TileSize: 32
@@ -93,7 +94,7 @@ MonoBehaviour:
       RenderQueueType: 0
       LayerMask:
         serializedVersion: 2
-        m_Bits: 128
+        m_Bits: 64
       PassNames: []
     overrideMaterial: {fileID: 0}
     overrideMaterialPassIndex: 0


### PR DESCRIPTION
This allows seeing both characters in the `Assets/Scenes/Renderer Features See Behind/HauntedMansion-SeeBehind.unity` scene.

![Layer Mask of SeeBehindSettings_Renderer](https://github.com/NikLever/Unity_URP_Videos/assets/738920/da24e24a-04fa-4b93-b3e5-755a8e671385)